### PR TITLE
`innerText` -> `innerHTML`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `*.min.*` scripts are minified.
         new MediumEditor(document.querySelector(".editor"), {
             extensions: {
                 markdown: new MeMarkdown(function (md) {
-                    markDownEl.innerText = md;
+                    markDownEl.innerHTML = md;
                 })
             }
         });


### PR DESCRIPTION
Now works in Firefox! Fixes #7 
