### PR TITLE
fix node module error #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
   "contributors": [
     "Nate Mielnik <nathan@outlook.com>",
-    "@prevuelta (http://www.pablorevuelta.com/)"
+    "@prevuelta (http://www.pablorevuelta.com/)",
+    "okmttdhr (http://okmttdhr.github.io/)"
   ],
   "license": "MIT",
   "dependencies": {

--- a/src/medium-editor-md.js
+++ b/src/medium-editor-md.js
@@ -11,6 +11,9 @@
  *
  * @param {Function} callback The callback function that is called with the markdown code (first argument).
  */
+
+var toMarkdown = require('to-markdown');
+
 module.exports = function (options, callback) {
 
     if (typeof options === "function") {


### PR DESCRIPTION
There was error when I import `medium-editor-markdown` (#16).

The problem was that it didn't define `toMarkdown`.
