### PR TITLE
2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
   "contributors": [
     "Nate Mielnik <nathan@outlook.com>",
-    "@prevuelta (http://www.pablorevuelta.com/)"
+    "@prevuelta (http://www.pablorevuelta.com/)",
+    "okmttdhr (http://okmttdhr.github.io/)"
   ],
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medium-editor-markdown",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A Medium Editor extension to add markdown support.",
   "main": "src/medium-editor-md.js",
   "directories": {

--- a/src/medium-editor-md.js
+++ b/src/medium-editor-md.js
@@ -11,6 +11,9 @@
  *
  * @param {Function} callback The callback function that is called with the markdown code (first argument).
  */
+
+var toMarkdown = require('to-markdown');
+
 module.exports = function (options, callback) {
 
     if (typeof options === "function") {


### PR DESCRIPTION
Merging @okmttdhr changes (/cc #17): declaring the `toMarkdown` variable, so this module can now be `require`d.

Fixes #16. Thanks, @okmttdhr! :sparkles: 
